### PR TITLE
Update Feature.sol: Enhanced 'Struct'

### DIFF
--- a/contracts/CentralizedAppealableArbitrator.sol
+++ b/contracts/CentralizedAppealableArbitrator.sol
@@ -177,12 +177,12 @@ contract CentralizedAppealableArbitrator is Arbitrator {
     uint256 public rulingTime;
 
     struct DisputeStruct {
-        IArbitrable arbitrated;
-        bool isAppealed;
         uint256 choices;
         uint256 fee;
         uint256 rulingAppealTimeOut;
         uint256 ruling;
+        IArbitrable arbitrated;
+        bool isAppealed;
         DisputeStatus status;
     }
 

--- a/contracts/CentralizedAppealableArbitrator.sol
+++ b/contracts/CentralizedAppealableArbitrator.sol
@@ -178,9 +178,9 @@ contract CentralizedAppealableArbitrator is Arbitrator {
 
     struct DisputeStruct {
         IArbitrable arbitrated;
+        bool isAppealed;
         uint256 choices;
         uint256 fee;
-        bool isAppealed;
         uint256 rulingAppealTimeOut;
         uint256 ruling;
         DisputeStatus status;

--- a/contracts/Feature.sol
+++ b/contracts/Feature.sol
@@ -478,6 +478,7 @@ contract Feature is Initializable, NativeMetaTransaction, ChainConstants, Contex
     }
 
     struct Transaction {
+        bool isExecuted;
         address sender;
         Arbitrator arbitrator; // The arbitrator of the contract.
         bytes arbitratorExtraData; // Extra data for the arbitrator.
@@ -487,7 +488,6 @@ contract Feature is Initializable, NativeMetaTransaction, ChainConstants, Contex
         uint256 delayClaim; // Time of the challenge period.
         string metaEvidence; // Link to the meta-evidence.
         uint256 runningClaimCount; // Count of running claims.
-        bool isExecuted;
     }
 
     struct Claim {

--- a/contracts/FeatureERC20.sol
+++ b/contracts/FeatureERC20.sol
@@ -458,6 +458,7 @@ contract FeatureERC20 is Initializable, NativeMetaTransaction, ChainConstants, C
     }
 
     struct Transaction {
+        bool isExecuted;
         address sender;
         Arbitrator arbitrator; // The arbitrator of the contract.
         bytes arbitratorExtraData; // Extra data for the arbitrator.
@@ -468,7 +469,6 @@ contract FeatureERC20 is Initializable, NativeMetaTransaction, ChainConstants, C
         uint256 delayClaim; // Time of the challenge period.
         string metaEvidence; // Link to the meta-evidence.
         uint256 runningClaimCount; // Count of running claims.
-        bool isExecuted;
     }
 
     struct Claim {


### PR DESCRIPTION
Shifting the `bool isExecuted` to the top of struct leads the contract to use one slot less than before. Cuz the boolean `isExecuted` and address `sender` got stored in a single slot, whereas earlier it was just occupying a single slot which leads to wastage of gas